### PR TITLE
FIX: Types on textFormatter method.

### DIFF
--- a/text-formatter.js
+++ b/text-formatter.js
@@ -4,11 +4,11 @@ import { visitParents } from "unist-util-visit-parents";
 /**
  * Formats the preview as plain text
  *
- * @param {object} options
- * @param {number} options.length - Max number of characters before truncating
- * @param {number} options.ellipsis - Adds an ellipsis to the end of the preview if necessasry.
+ * @param {object} [options]
+ * @param {number} [options.length] - Max number of characters before truncating
+ * @param {boolean} [options.ellipsis] - Adds an ellipsis to the end of the preview if necessasry.
  * @param {number} options.maxBlocks - Max number of block elements to include
- * @param {number} options.headings - Whether or not to include headings
+ * @param {boolean} [options.headings] - Whether or not to include headings
  */
 export default function textFormatter({
   length = 300,


### PR DESCRIPTION
This PR is introduced to fix the parameters used for `textFormatter` as it was stating booleans were numbers and the optional properties were not defined correctly in JSdocs.